### PR TITLE
Deploy GitHub pages site with Jekyll no-style-please

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,5 @@
+title: "My Personal Page"
+theme: "no-style-please"
+baseurl: ""
+url: "https://d33pk3rn3l.github.io"
+markdown: kramdown

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,3 @@
+<footer>
+    <p>&copy; 2024 My Personal Page. All rights reserved.</p>
+</footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,7 @@
+<nav>
+    <ul>
+        <li><a href="{{ site.baseurl }}/">Home</a></li>
+        <li><a href="{{ site.baseurl }}/projects">Projects</a></li>
+        <li><a href="{{ site.baseurl }}/blog">Blog</a></li>
+    </ul>
+</nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title }}</title>
+    {% include head.html %}
+</head>
+<body>
+    {% include header.html %}
+    <div class="content">
+        {{ content }}
+    </div>
+    {% include footer.html %}
+</body>
+</html>

--- a/_posts/2024-01-01-welcome-to-my-blog.md
+++ b/_posts/2024-01-01-welcome-to-my-blog.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: "Welcome to My Blog"
+date: 2024-01-01
+---
+
+Welcome to the Space System Engineering digital garden! This repository summarizes the lecture Space System Engineering held at ETH Zurich by Prof. Dr. Thomas Zurbuchen, Dr. Simon Christian Stähler, and Dr. Florian Kehl. The lecture is part of the Master’s program in Space Systems.
+
+This digital garden is a network of interconnected ideas, notes, and summaries that capture the essence of the lecture, primarily based on the book Space Mission Engineering: The New SMAD by James R. Wertz and Wiley J. Larson.
+
+Check out the reference page [here](https://d33pk3rn3l.github.io/sse_page/).

--- a/index.html
+++ b/index.html
@@ -1,25 +1,17 @@
+---
+layout: default
+title: "Personal Page"
+---
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Personal Page</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+    <title>{{ page.title }}</title>
 </head>
 <body>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="#">My Personal Page</a>
-        <div class="collapse navbar-collapse">
-            <ul class="navbar-nav mr-auto">
-                <li class="nav-item">
-                    <a class="nav-link" href="#projects">Projects</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="#thoughts">Thoughts/Blog</a>
-                </li>
-            </ul>
-        </div>
-    </nav>
+    {% include header.html %}
 
     <div class="container">
         <section id="projects">
@@ -30,10 +22,29 @@
         <section id="thoughts">
             <h2>Thoughts/Blog</h2>
             <!-- Add your blog posts here -->
+            {% for post in site.posts %}
+                <article>
+                    <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
+                    <p>{{ post.excerpt }}</p>
+                </article>
+            {% endfor %}
+        </section>
+
+        <section id="archive">
+            <h2>Archive</h2>
+            <ul>
+                {% for post in site.posts %}
+                    <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+                {% endfor %}
+            </ul>
+        </section>
+
+        <section id="first-post">
+            <h2>First Post</h2>
+            <p>Check out my first post <a href="https://d33pk3rn3l.github.io/sse_page/">here</a>.</p>
         </section>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"></script>
+    {% include footer.html %}
 </body>
 </html>


### PR DESCRIPTION
Deploy a GitHub pages site with the Jekyll theme from the no-style-please repository.

* Add `_config.yml` with site configuration including title, theme, baseurl, url, and markdown settings.
* Modify `index.html` to use Jekyll front matter, remove Bootstrap, include Jekyll header and footer, add sections for projects, blog posts, archive, and first post reference.
* Add `_layouts/default.html` with HTML5 doctype, head section, Jekyll includes for header and footer, and content block.
* Add `_includes/header.html` with navigation bar links to home, projects, and blog.
* Add `_includes/footer.html` with footer content.
* Add `_posts/2024-01-01-welcome-to-my-blog.md` with Jekyll front matter, sample blog post content, and reference to the specified page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/d33pk3rn3l/d33pk3rn3l.github.io/pull/1?shareId=9cc4929a-fb6e-4bfe-8e32-c32cc54da1cf).